### PR TITLE
Set arg static_folder to static directory in run_visualization.py

### DIFF
--- a/run_visualization.py
+++ b/run_visualization.py
@@ -8,7 +8,7 @@ import matplotlib.image as image
 from matplotlib.colors import LinearSegmentedColormap
 from flask import Flask, send_from_directory, jsonify, request
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='client/build')
 
 @app.route('/', defaults={'path': ''})
 @app.route('/<path:path>')

--- a/run_visualization.py
+++ b/run_visualization.py
@@ -8,8 +8,7 @@ import matplotlib.image as image
 from matplotlib.colors import LinearSegmentedColormap
 from flask import Flask, send_from_directory, jsonify, request
 
-app = Flask(__name__, static_folder='')
-
+app = Flask(__name__)
 
 @app.route('/', defaults={'path': ''})
 @app.route('/<path:path>')


### PR DESCRIPTION
This PR allows `run_visualization.py` run fine.
Refer #22 
```sh
CapsNet-Visualization % python run_visualization.py
 * Serving Flask app "run_visualization" (lazy loading)
 * Environment: production
   WARNING: Do not use the development server in a production environment.
   Use a production WSGI server instead.
 * Debug mode: on
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 205-424-827
127.0.0.1 - - [06/May/2020 00:40:12] "GET /favicon.ico HTTP/1.1" 200 -
127.0.0.1 - - [06/May/2020 00:40:12] "GET /images HTTP/1.1" 200 -
127.0.0.1 - - [06/May/2020 00:40:13] "GET /service-worker.js HTTP/1.1" 304 -
```
![image](https://user-images.githubusercontent.com/17569894/81085485-3ba49500-8f32-11ea-98d8-a41be7701f99.png)
